### PR TITLE
Opening up public access for inception

### DIFF
--- a/inception/src/main.rs
+++ b/inception/src/main.rs
@@ -10,7 +10,8 @@ use std::{
 fn main() {
 
     //create tcp listner on port 7878
-    let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
+    //let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
+    let listener = TcpListener::bind("0.0.0.0:7878").unwrap();
 
     //for each incoming connection attempt
     for stream in listener.incoming() {


### PR DESCRIPTION
1. Opening up public access for our TcpListner
2. Changed the Network type to Bridged in VM settings.
3. Verified using the public address from laptop and mobile